### PR TITLE
Implement F1-Score metric

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -69,7 +69,7 @@ async def legacy_get_all_recipes(
 
 async def evaluate_nls_method(method_name, search_func, queries, id_to_title):
     print("------------------------------------------------------------------------")
-    print(f"Evaluating '{method_name}', Top {LIMIT_TOP_K} results are evaluated")
+    print(f"Evaluating '{method_name}', top {LIMIT_TOP_K} results are evaluated")
     
     passed = 0
     total = len(queries)


### PR DESCRIPTION
Introduced the F1-Score metric to the evaluation script. This provides a more nuanced assessment of search quality by balancing Precision and Recall, offering a deeper insight into the system's performance beyond simple accuracy rates

In addition, thanks to updating the dataset to support multiple expected_ids (taking into account alternative correct answers in broad or abstract queries), the measured performance of vector search has improved significantly. I also introduced the LIMIT_TOP_K parameter to limit the evaluation to the top five results. This provides a fairer comparison by putting both methods on equal footing and focusing on the quality of the highest-ranked results.

### MySQL Full-Text Search
```
------------------------------------------------------------------------
Evaluating 'MySQL Full-Text Search', top 5 results are evaluated
By category:
 - semantic_description     :  40.00% | F1: 0.4000 (2/5)
 - semantic_visual          :  60.00% | F1: 0.2667 (3/5)
 - semantic_synonym         :   0.00% | F1: 0.0000 (0/5)
 - abstract_concept         :   0.00% | F1: 0.0000 (0/5)
 - abstract_usage           :   0.00% | F1: 0.0000 (0/5)
 - synonym_ingredient       :  40.00% | F1: 0.1943 (2/5)
 - semantic_process         :  60.00% | F1: 0.2038 (3/5)
 - ingredient_context       :  40.00% | F1: 0.4000 (2/5)
 - abstract_emotion         :  60.00% | F1: 0.5333 (3/5)
 - cultural_reference       :   0.00% | F1: 0.0000 (0/5)
 - synonym_scientific       :  20.00% | F1: 0.1333 (1/5)
 - ingredient_description   :  60.00% | F1: 0.3333 (3/5)
 - abstract_nutrient        :  60.00% | F1: 0.4533 (3/5)
 - semantic_mistake         : 100.00% | F1: 0.3933 (5/5)
 - negation                 :  80.00% | F1: 0.4276 (4/5)
 - negation_complex         :  20.00% | F1: 0.1000 (1/5)
 - synonym                  :  40.00% | F1: 0.4000 (2/5)
 - direct_ingredient        :  20.00% | F1: 0.1143 (1/5)
 - definition               : 100.00% | F1: 0.3800 (5/5)
 - metaphor                 :  60.00% | F1: 0.3667 (3/5)
 - broad                    :  60.00% | F1: 0.4167 (3/5)
 - reordering               : 100.00% | F1: 0.7143 (5/5)
 - vague                    :  40.00% | F1: 0.1444 (2/5)
 - semantic_abstract        :  20.00% | F1: 0.1000 (1/5)
 - contextual_slang         :  40.00% | F1: 0.2000 (2/5)
 - contextual_mood          :  60.00% | F1: 0.5200 (3/5)
 - semantic_trick           :  80.00% | F1: 0.4533 (4/5)
 - synonym_childish         :  80.00% | F1: 0.3514 (4/5)
 - marketing_slang          :  60.00% | F1: 0.4333 (3/5)
 - misleading               :  60.00% | F1: 0.2371 (3/5)
 - visual_desc              :  80.00% | F1: 0.4038 (4/5)
 - riddle                   :  40.00% | F1: 0.3333 (2/5)
 - chemical                 :  80.00% | F1: 0.4400 (4/5)
 - difficulty_desc          : 100.00% | F1: 0.6667 (5/5)
 - semantic                 :  40.00% | F1: 0.2000 (2/5)
 - abstract_mood            :  80.00% | F1: 0.3967 (4/5)
Overall Accuracy: 52.22222222222223% (94/180)
Average latency: 1.27607 ms
Mean Reciprocal Rank (MRR): 0.45787
Zero Result Rate (ZRR): 27.78%
Average F1-Score: 0.3086
------------------------------------------------------------------------
```

### Vector Search
```
------------------------------------------------------------------------
Evaluating 'Vector search', top 5 results are evaluated
By category:
 - semantic_description     : 100.00% | F1: 0.3238 (5/5)
 - semantic_visual          : 100.00% | F1: 0.4762 (5/5)
 - semantic_synonym         : 100.00% | F1: 0.4167 (5/5)
 - abstract_concept         : 100.00% | F1: 0.4889 (5/5)
 - abstract_usage           : 100.00% | F1: 0.3789 (5/5)
 - synonym_ingredient       :  80.00% | F1: 0.3619 (4/5)
 - semantic_process         : 100.00% | F1: 0.4286 (5/5)
 - ingredient_context       : 100.00% | F1: 0.4286 (5/5)
 - abstract_emotion         :  80.00% | F1: 0.3981 (4/5)
 - cultural_reference       : 100.00% | F1: 0.4952 (5/5)
 - synonym_scientific       :  80.00% | F1: 0.3048 (4/5)
 - ingredient_description   :  80.00% | F1: 0.3143 (4/5)
 - abstract_nutrient        : 100.00% | F1: 0.4952 (5/5)
 - semantic_mistake         : 100.00% | F1: 0.3810 (5/5)
 - negation                 : 100.00% | F1: 0.4857 (5/5)
 - negation_complex         : 100.00% | F1: 0.4127 (5/5)
 - synonym                  : 100.00% | F1: 0.3810 (5/5)
 - direct_ingredient        : 100.00% | F1: 0.4190 (5/5)
 - definition               : 100.00% | F1: 0.3333 (5/5)
 - metaphor                 : 100.00% | F1: 0.2738 (5/5)
 - broad                    : 100.00% | F1: 0.4870 (5/5)
 - reordering               : 100.00% | F1: 0.3810 (5/5)
 - vague                    : 100.00% | F1: 0.5924 (5/5)
 - semantic_abstract        : 100.00% | F1: 0.4889 (5/5)
 - contextual_slang         :  80.00% | F1: 0.3789 (4/5)
 - contextual_mood          :  80.00% | F1: 0.2781 (4/5)
 - semantic_trick           : 100.00% | F1: 0.4762 (5/5)
 - synonym_childish         : 100.00% | F1: 0.5024 (5/5)
 - marketing_slang          : 100.00% | F1: 0.4190 (5/5)
 - misleading               : 100.00% | F1: 0.4190 (5/5)
 - visual_desc              : 100.00% | F1: 0.3810 (5/5)
 - riddle                   : 100.00% | F1: 0.4619 (5/5)
 - chemical                 : 100.00% | F1: 0.4643 (5/5)
 - difficulty_desc          : 100.00% | F1: 0.3810 (5/5)
 - semantic                 : 100.00% | F1: 0.5452 (5/5)
 - abstract_mood            : 100.00% | F1: 0.4616 (5/5)
Overall Accuracy: 96.66666666666667% (174/180)
Average latency: 150.57793 ms
Mean Reciprocal Rank (MRR): 0.83120
Zero Result Rate (ZRR): 0.00%
Average F1-Score: 0.4199
------------------------------------------------------------------------
```

| Metric | MySQL Full-Text Search | Vector Search
| :--- | :---: | :---: |
| **Overall Accuracy** | 52.22% | **96.67%** |
| **Average Latency** | **1.28 ms** | 150.58 ms |
| **Mean Reciprocal Rank** (MRR) | 0.45787 | **0.83120** |
| **Zero Result Rate** | 27.78% | **0.00%** |
| **Average F1-Score** | 0.3086 | **0.4199** |

Ref #18 